### PR TITLE
Added option to turn device children on as in EP40.

### DIFF
--- a/Kasa/Data/Child.cs
+++ b/Kasa/Data/Child.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Kasa;
+
+    /// <summary>
+    /// Child element for outlet device with more than one plug
+    /// </summary>
+    public struct Child {
+        [JsonProperty("id")] public string id { get; set; }  //  "800671BEB946D3C691ECBD2940991375202E165600",
+        [JsonProperty("state")] public string state { get; set; }  //  1,
+        [JsonProperty("alias")] public string alias { get; set; }  //  "Outside Plug 1",
+        [JsonProperty("on_time")] public string on_time { get; set; }  //  1882,
+
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        public static Feature FromJsonString(string jsonString) => jsonString.ToUpperInvariant() switch {
+            "TIM" => Feature.Timer,
+            "ENE" => Feature.EnergyMeter,
+            _     => throw new ArgumentOutOfRangeException(nameof(jsonString), jsonString, "Unknown feature")
+        };
+    }

--- a/Kasa/Data/SystemInfo.cs
+++ b/Kasa/Data/SystemInfo.cs
@@ -93,4 +93,8 @@ public struct SystemInfo {
     /// </summary>
     [JsonProperty("feature")] public ISet<Feature> Features { get; internal set; }
 
+    /// <summary>
+    /// Children switches in a single device
+    /// </summary>
+    [JsonProperty("children")] public ISet<Child> Children { get; internal set; }
 }

--- a/Kasa/Data/Timer.cs
+++ b/Kasa/Data/Timer.cs
@@ -62,6 +62,7 @@ public struct Timer {
         IsEnabled       = true;
         TotalDuration   = duration;
         WillSetOutletOn = willSetOutletOn;
+        RemainingDuration = duration;  // Necissary to build.        
     }
 
 }

--- a/Kasa/IKasaClient.cs
+++ b/Kasa/IKasaClient.cs
@@ -17,6 +17,6 @@ internal interface IKasaClient: IDisposable {
     /// <exception cref="FeatureUnavailable">If the device is missing a feature that is required to run the given method, such as running <c>EnergyMeter.GetInstantaneousPowerUsage()</c> on an EP10, which does not have the EnergyMeter Feature.</exception>
     /// <exception cref="NetworkException">if the TCP connection to the outlet failed and could not automatically reconnect</exception>
     /// <exception cref="ResponseParsingException">if the JSON received from the outlet contained unexpected data</exception>
-    Task<T> Send<T>(CommandFamily commandFamily, string methodName, object? parameters = null);
+    Task<T> Send<T>(CommandFamily commandFamily, string methodName, object? parameters = null, string[]? childIds = null);
 
 }

--- a/Kasa/IKasaOutlet.cs
+++ b/Kasa/IKasaOutlet.cs
@@ -99,6 +99,18 @@ public interface IKasaOutlet: IDisposable {
         Task SetOutletOn(bool turnOn);
 
         /// <summary>
+        /// <para>Turn on or off the device's children outlets so it can supply power to any connected electrical consumers or not.</para>
+        /// <para>You can also toggle the outlet by pressing the physical button on the device.</para>
+        /// <para>This call is idempotent: if you try to turn the outlet on and it's already on, the call will have no effect.</para>
+        /// <para>The state is persisted across restarts. If the device loses power, it will restore the previous outlet power state when it turns on again.</para>
+        /// <para>This call is unrelated to turning the entire Kasa device on or off. To reboot the device, use <see cref="Reboot"/>.</para>
+        /// </summary>
+        /// <param name="turnOnChild"><c>true</c> to supply power to the outlet, or <c>false</c> to switch if off.</param>
+        /// <exception cref="NetworkException">if the TCP connection to the outlet failed and could not automatically reconnect</exception>
+        /// <exception cref="ResponseParsingException">if the JSON received from the outlet contained unexpected data</exception>
+        Task SetAllChildOutletOn(bool turnOn);
+
+        /// <summary>
         /// <para>Get data about the device, including hardware, software, configuration, and current state.</para>
         /// </summary>
         /// <returns>Data about the device</returns>

--- a/Kasa/KasaOutlet.System.cs
+++ b/Kasa/KasaOutlet.System.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
@@ -18,6 +19,29 @@ public partial class KasaOutlet {
     /// <inheritdoc />
     Task IKasaOutlet.ISystemCommands.SetOutletOn(bool turnOn) {
         return _client.Send<JObject>(CommandFamily.System, "set_relay_state", new { state = Convert.ToInt32(turnOn) });
+    }
+
+    /// <inheritdoc />
+    Task IKasaOutlet.ISystemCommands.SetAllChildOutletOn(bool turnOn)
+    {
+        var systemInfo = System.GetInfo().Result;
+
+        if (systemInfo.Children == null)
+        {
+            // No children are found, return.
+            return Task.FromResult(false);
+        }
+			 
+        // In order to support multiple outlets, a 'context' node must be added:
+        // {"system":{"set_relay_state":{"state":0}},"context":{"child_ids":["etc00", "etc01]}}
+        // https://community.home-assistant.io/t/tp-link-kasa-kp400-2-outlet-support/113135/9
+       
+        string[] children = systemInfo.Children.Select(child => child.id).ToArray();
+        var commandParameters = new { state = Convert.ToInt32(turnOn) };
+
+        //var serializedObject = Newtonsoft.Json.JsonConvert.SerializeObject(commandParameters); // Debug
+        // Include array of children IDs to Send<JObject>().
+        return _client.Send<JObject>(CommandFamily.System, "set_relay_state", commandParameters, children);
     }
 
     /// <inheritdoc />

--- a/Test/KasaOutletEnergyMeterTest.cs
+++ b/Test/KasaOutletEnergyMeterTest.cs
@@ -10,7 +10,7 @@ public class KasaOutletEnergyMeterTest: AbstractKasaOutletTest {
     [Fact]
     public async Task GetInstantaneousPowerUsage() {
         PowerUsage expected = new() { Current = 18, Voltage = 121995, Power = 967, CumulativeEnergySinceBoot = 0 };
-        A.CallTo(() => Client.Send<PowerUsage>(CommandFamily.EnergyMeter, "get_realtime", null)).Returns(expected);
+        A.CallTo(() => Client.Send<PowerUsage>(CommandFamily.EnergyMeter, "get_realtime", null, null)).Returns(expected);
         PowerUsage actual = await Outlet.EnergyMeter.GetInstantaneousPowerUsage();
         actual.Current.Should().Be(18);
         actual.Voltage.Should().Be(121995);
@@ -21,7 +21,7 @@ public class KasaOutletEnergyMeterTest: AbstractKasaOutletTest {
     [Fact]
     public async Task GetDailyEnergyUsageOneDay() {
         JObject json = JObject.Parse(@"{""day_list"": [{""year"": 2022, ""month"": 5, ""day"": 31, ""energy_wh"": 6}]}");
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.EnergyMeter, "get_daystat", An<object>.That.Matches(o => o.Should().BeEquivalentTo(new { year = 2022, month = 5 }, "")))).Returns(json);
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.EnergyMeter, "get_daystat", An<object>.That.Matches(o => o.Should().BeEquivalentTo(new { year = 2022, month = 5 }, "")), null)).Returns(json);
         IList<int>? actual = await Outlet.EnergyMeter.GetDailyEnergyUsage(2022, 5);
         actual.Should().HaveCount(31);
         actual.Should().BeEquivalentTo(new List<int> { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6 });
@@ -30,7 +30,7 @@ public class KasaOutletEnergyMeterTest: AbstractKasaOutletTest {
     [Fact]
     public async Task GetDailyEnergyUsageTwoDays() {
         JObject json = JObject.Parse(@"{""day_list"": [{""year"": 2022, ""month"": 6, ""day"": 1, ""energy_wh"": 22}, {""year"": 2022, ""month"": 6, ""day"": 2, ""energy_wh"": 1}]}");
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.EnergyMeter, "get_daystat", An<object>.That.Matches(o => o.Should().BeEquivalentTo(new { year = 2022, month = 6 }, "")))).Returns(json);
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.EnergyMeter, "get_daystat", An<object>.That.Matches(o => o.Should().BeEquivalentTo(new { year = 2022, month = 6 }, "")), null)).Returns(json);
         IList<int>? actual = await Outlet.EnergyMeter.GetDailyEnergyUsage(2022, 6);
         actual.Should().HaveCount(30);
         actual.Should().BeEquivalentTo(new List<int> { 22, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
@@ -39,7 +39,7 @@ public class KasaOutletEnergyMeterTest: AbstractKasaOutletTest {
     [Fact]
     public async Task GetDailyEnergyUsageNotFound() {
         JObject json = JObject.Parse(@"{""day_list"": []}");
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.EnergyMeter, "get_daystat", An<object>.That.Matches(o => o.Should().BeEquivalentTo(new { year = 2022, month = 4 }, "")))).Returns(json);
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.EnergyMeter, "get_daystat", An<object>.That.Matches(o => o.Should().BeEquivalentTo(new { year = 2022, month = 4 }, "")), null)).Returns(json);
         IList<int>? actual = await Outlet.EnergyMeter.GetDailyEnergyUsage(2022, 4);
         actual.Should().BeNull();
     }
@@ -47,7 +47,7 @@ public class KasaOutletEnergyMeterTest: AbstractKasaOutletTest {
     [Fact]
     public async Task GetMonthlyEnergyUsage() {
         JObject json = JObject.Parse(@"{""month_list"": [{""year"": 2022, ""month"": 5, ""energy_wh"": 6}, {""year"": 2022, ""month"": 6, ""energy_wh"": 18}]}");
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.EnergyMeter, "get_monthstat", An<object>.That.HasProperty("year", 2022))).Returns(json);
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.EnergyMeter, "get_monthstat", An<object>.That.HasProperty("year", 2022), null)).Returns(json);
         IList<int>? actual = await Outlet.EnergyMeter.GetMonthlyEnergyUsage(2022);
         actual.Should().BeEquivalentTo(new List<int> { 0, 0, 0, 0, 6, 18, 0, 0, 0, 0, 0, 0 });
     }
@@ -55,7 +55,7 @@ public class KasaOutletEnergyMeterTest: AbstractKasaOutletTest {
     [Fact]
     public async Task GetMonthlyEnergyUsageNotFound() {
         JObject json = JObject.Parse(@"{""month_list"": []}");
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.EnergyMeter, "get_monthstat", An<object>.That.HasProperty("year", 2021))).Returns(json);
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.EnergyMeter, "get_monthstat", An<object>.That.HasProperty("year", 2021), null)).Returns(json);
         IList<int>? actual = await Outlet.EnergyMeter.GetMonthlyEnergyUsage(2021);
         actual.Should().BeNull();
     }
@@ -63,7 +63,7 @@ public class KasaOutletEnergyMeterTest: AbstractKasaOutletTest {
     [Fact]
     public async Task ClearHistoricalUsage() {
         await Outlet.EnergyMeter.DeleteHistoricalUsage();
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.EnergyMeter, "erase_emeter_stat", null)).MustHaveHappened();
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.EnergyMeter, "erase_emeter_stat", null, null)).MustHaveHappened();
     }
 
 }

--- a/Test/KasaOutletScheduleTest.cs
+++ b/Test/KasaOutletScheduleTest.cs
@@ -11,7 +11,7 @@ public class KasaOutletScheduleTest: AbstractKasaOutletTest {
     public async Task GetAll() {
         JObject json = JObject.Parse(
             @"{""rule_list"":[{""id"":""FDC476554A5FC2936AD6EF14E6950DF9"",""name"":""Schedule Rule"",""enable"":1,""wday"":[1,1,0,0,0,0,0],""stime_opt"":0,""smin"":195,""sact"":1,""eact"":-1,""repeat"":1},{""id"":""901F46B4FFC33957D2A5383F2F83BDE0"",""name"":""Schedule Rule"",""enable"":1,""wday"":[0,0,1,1,0,0,0],""stime_opt"":1,""smin"":356,""soffset"":5,""sact"":0,""eact"":-1,""repeat"":1},{""id"":""13B98EDB80160333AF59C23B73036378"",""name"":""Schedule Rule"",""enable"":0,""wday"":[0,0,0,0,1,1,1],""stime_opt"":2,""smin"":1222,""soffset"":-10,""sact"":1,""eact"":-1,""repeat"":1}],""version"":2,""enable"":1,""err_code"":0}");
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Schedule, "get_rules", null)).Returns(json);
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Schedule, "get_rules", null, null)).Returns(json);
 
         IList<Schedule> actual = (await Outlet.Schedule.GetAll()).ToArray();
         actual[0].Id.Should().Be("FDC476554A5FC2936AD6EF14E6950DF9");
@@ -47,8 +47,8 @@ public class KasaOutletScheduleTest: AbstractKasaOutletTest {
 
     [Fact]
     public async Task Insert() {
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Schedule, "add_rule", A<Schedule>._)).Returns(JObject.Parse(@"{""id"":""FE25867C0F5B34E3B83552888CAC5668"",""err_code"":0}"));
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Schedule, "get_rules", null)).Returns(JObject.Parse(
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Schedule, "add_rule", A<Schedule>._, null)).Returns(JObject.Parse(@"{""id"":""FE25867C0F5B34E3B83552888CAC5668"",""err_code"":0}"));
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Schedule, "get_rules", null, null)).Returns(JObject.Parse(
             @"{""rule_list"":[{""id"":""FE25867C0F5B34E3B83552888CAC5668"",""name"":""Schedule Rule"",""enable"":1,""wday"":[0,0,1,1,1,0,0],""stime_opt"":0,""smin"":1185,""sact"":1,""eact"":-1,""repeat"":1}],""version"":2,""enable"":1,""err_code"":0}"));
 
         Schedule actual = await Outlet.Schedule.Save(new Schedule(true, new[] { DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday }, new TimeOnly(7 + 12, 45)));
@@ -65,8 +65,8 @@ public class KasaOutletScheduleTest: AbstractKasaOutletTest {
 
     [Fact]
     public async Task Update() {
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Schedule, "edit_rule", A<Schedule>._)).Returns(JObject.Parse(@"{""err_code"":0}"));
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Schedule, "get_rules", null)).Returns(JObject.Parse(
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Schedule, "edit_rule", A<Schedule>._, null)).Returns(JObject.Parse(@"{""err_code"":0}"));
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Schedule, "get_rules", null, null)).Returns(JObject.Parse(
             @"{""rule_list"":[{""id"":""FE25867C0F5B34E3B83552888CAC5668"",""name"":""Schedule Rule"",""enable"":0,""wday"":[0,0,1,1,1,0,0],""stime_opt"":0,""smin"":1185,""sact"":1,""eact"":-1,""repeat"":1}],""version"":2,""enable"":1,""err_code"":0}"));
 
         Schedule actual = await Outlet.Schedule.Save(new Schedule(true, new[] { DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday }, new TimeOnly(7 + 12, 45))
@@ -85,7 +85,7 @@ public class KasaOutletScheduleTest: AbstractKasaOutletTest {
     [Fact]
     public async Task Delete() {
         JObject json = JObject.Parse(@"{""err_code"":0}");
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Schedule, "delete_rules", A<object>.That.HasProperty("id", "123"))).Returns(json);
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Schedule, "delete_rules", A<object>.That.HasProperty("id", "123"), null)).Returns(json);
 
         Schedule schedule = new() { Id = "123" };
         await Outlet.Schedule.Delete(schedule);
@@ -101,7 +101,7 @@ public class KasaOutletScheduleTest: AbstractKasaOutletTest {
     [Fact]
     public async Task DeleteById() {
         JObject json = JObject.Parse(@"{""err_code"":0}");
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Schedule, "delete_rules", A<object>.That.HasProperty("id", "123"))).Returns(json);
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Schedule, "delete_rules", A<object>.That.HasProperty("id", "123"), null)).Returns(json);
 
         await Outlet.Schedule.Delete("123");
     }
@@ -109,7 +109,7 @@ public class KasaOutletScheduleTest: AbstractKasaOutletTest {
     [Fact]
     public async Task DeleteAll() {
         JObject json = JObject.Parse(@"{""err_code"":0}");
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Schedule, "delete_all_rules", null)).Returns(json);
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Schedule, "delete_all_rules", null, null)).Returns(json);
 
         await Outlet.Schedule.DeleteAll();
     }

--- a/Test/KasaOutletSystemTest.cs
+++ b/Test/KasaOutletSystemTest.cs
@@ -11,7 +11,7 @@ public class KasaOutletSystemTest: AbstractKasaOutletTest {
     [InlineData(true)]
     [InlineData(false)]
     public async Task IsOutletOn(bool expected) {
-        A.CallTo(() => Client.Send<SystemInfo>(CommandFamily.System, "get_sysinfo", null)).Returns(new SystemInfo {
+        A.CallTo(() => Client.Send<SystemInfo>(CommandFamily.System, "get_sysinfo", null, null)).Returns(new SystemInfo {
             IsOutletOn = expected
         });
 
@@ -25,13 +25,13 @@ public class KasaOutletSystemTest: AbstractKasaOutletTest {
     [InlineData(false, 0)]
     public async Task TurnOutletOn(bool turnOn, int expected) {
         await Outlet.System.SetOutletOn(turnOn);
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.System, "set_relay_state", An<object>.That.Matches(o => o.Should().BeEquivalentTo(new { state = expected }, "")))).MustHaveHappened();
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.System, "set_relay_state", An<object>.That.Matches(o => o.Should().BeEquivalentTo(new { state = expected }, "")), null)).MustHaveHappened();
     }
 
     [Fact]
     public async Task GetSystemInfo() {
         SystemInfo expected = new();
-        A.CallTo(() => Client.Send<SystemInfo>(CommandFamily.System, "get_sysinfo", null)).Returns(expected);
+        A.CallTo(() => Client.Send<SystemInfo>(CommandFamily.System, "get_sysinfo", null, null)).Returns(expected);
 
         SystemInfo actual = await Outlet.System.GetInfo();
         actual.Should().Be(expected);
@@ -41,7 +41,7 @@ public class KasaOutletSystemTest: AbstractKasaOutletTest {
     [InlineData(true, false)]
     [InlineData(false, true)]
     public async Task IsIndicatorLightOn(bool indicatorLightDisabled, bool expected) {
-        A.CallTo(() => Client.Send<SystemInfo>(CommandFamily.System, "get_sysinfo", null)).Returns(new SystemInfo {
+        A.CallTo(() => Client.Send<SystemInfo>(CommandFamily.System, "get_sysinfo", null, null)).Returns(new SystemInfo {
             IndicatorLightDisabled = indicatorLightDisabled
         });
 
@@ -55,18 +55,18 @@ public class KasaOutletSystemTest: AbstractKasaOutletTest {
     [InlineData(false, 1)]
     public async Task TurnIndicatorLightOn(bool turnOn, int expected) {
         await Outlet.System.SetIndicatorLightOn(turnOn);
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.System, "set_led_off", An<object>.That.HasProperty("off", expected))).MustHaveHappened();
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.System, "set_led_off", An<object>.That.HasProperty("off", expected), null)).MustHaveHappened();
     }
 
     [Fact]
     public async Task Reboot() {
         await Outlet.System.Reboot(TimeSpan.FromSeconds(5));
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.System, "reboot", An<object>.That.HasProperty("delay", 5))).MustHaveHappened();
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.System, "reboot", An<object>.That.HasProperty("delay", 5), null)).MustHaveHappened();
     }
 
     [Fact]
     public async Task GetName() {
-        A.CallTo(() => Client.Send<SystemInfo>(CommandFamily.System, "get_sysinfo", null)).Returns(new SystemInfo {
+        A.CallTo(() => Client.Send<SystemInfo>(CommandFamily.System, "get_sysinfo", null, null)).Returns(new SystemInfo {
             Name = "SX20"
         });
 
@@ -78,7 +78,7 @@ public class KasaOutletSystemTest: AbstractKasaOutletTest {
     [Fact]
     public async Task SetName() {
         await Outlet.System.SetName("abc");
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.System, "set_dev_alias", An<object>.That.HasProperty("alias", "abc"))).MustHaveHappened();
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.System, "set_dev_alias", An<object>.That.HasProperty("alias", "abc"), null)).MustHaveHappened();
     }
 
     [Theory]
@@ -88,7 +88,7 @@ public class KasaOutletSystemTest: AbstractKasaOutletTest {
     public async Task SetNameInvalid(string name) {
         Func<Task> setName = async () => await Outlet.System.SetName(name);
         await setName.Should().ThrowAsync<ArgumentOutOfRangeException>();
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.System, "set_dev_alias", An<object>._)).MustNotHaveHappened();
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.System, "set_dev_alias", An<object>._, null)).MustNotHaveHappened();
     }
 
 }

--- a/Test/KasaOutletTimeTest.cs
+++ b/Test/KasaOutletTimeTest.cs
@@ -10,7 +10,7 @@ public class KasaOutletTimeTest: AbstractKasaOutletTest {
     [Fact]
     public async Task GetTime() {
         JObject json = JObject.Parse(@"{""year"":2022,""month"":5,""mday"":29,""hour"":22,""min"":33,""sec"":22}");
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Time, "get_time", null)).Returns(json);
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Time, "get_time", null, null)).Returns(json);
 
         DateTime actual = await Outlet.Time.GetTime();
         actual.Should().Be(new DateTime(2022, 5, 29, 22, 33, 22));
@@ -24,15 +24,15 @@ public class KasaOutletTimeTest: AbstractKasaOutletTest {
     [InlineData(75, "India Standard Time")]
     public async Task GetTimeZones(int kasaZoneIndex, string windowsZoneId) {
         JObject json = new(new JProperty("index", kasaZoneIndex));
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Time, "get_timezone", null)).Returns(json);
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Time, "get_timezone", null, null)).Returns(json);
         IEnumerable<TimeZoneInfo> actual = await Outlet.Time.GetTimeZones();
         actual.Should().Contain(info => info.Id == windowsZoneId);
     }
 
     [Fact]
     public async Task GetTimeZoneWithOffset() {
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Time, "get_time", null)).Returns(JObject.Parse(@"{""year"":2022,""month"":5,""mday"":29,""hour"":22,""min"":33,""sec"":22}"));
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Time, "get_timezone", null)).Returns(new JObject(new JProperty("index", 6)));
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Time, "get_time", null, null)).Returns(JObject.Parse(@"{""year"":2022,""month"":5,""mday"":29,""hour"":22,""min"":33,""sec"":22}"));
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Time, "get_timezone", null, null)).Returns(new JObject(new JProperty("index", 6)));
 
         DateTimeOffset actual = await Outlet.Time.GetTimeWithZoneOffset();
 
@@ -47,7 +47,7 @@ public class KasaOutletTimeTest: AbstractKasaOutletTest {
     [InlineData(75, "India Standard Time")]
     public async Task SetTimeZone(int kasaZoneIndex, string windowsZoneId) {
         await Outlet.Time.SetTimeZone(TimeZoneInfo.FindSystemTimeZoneById(windowsZoneId));
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Time, "set_timezone", An<object>.That.HasProperty("index", kasaZoneIndex))).MustHaveHappened();
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Time, "set_timezone", An<object>.That.HasProperty("index", kasaZoneIndex), null)).MustHaveHappened();
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class KasaOutletTimeTest: AbstractKasaOutletTest {
         map[kasaId] = new[] { "fake windows timezone ID" };
 
         JObject json = new(new JProperty("index", kasaId));
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Time, "get_timezone", null)).Returns(json);
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Time, "get_timezone", null, null)).Returns(json);
 
         IEnumerable<TimeZoneInfo> actual = await Outlet.Time.GetTimeZones();
         actual.Should().BeEmpty();

--- a/Test/KasaOutletTimerTest.cs
+++ b/Test/KasaOutletTimerTest.cs
@@ -11,7 +11,7 @@ public class KasaOutletTimerTest: AbstractKasaOutletTest {
     [Fact]
     public async Task GetOne() {
         JObject json = JObject.Parse(@"{""rule_list"":[{""id"":""BD8AED3F853C175935F0A5BC24C454F4"",""name"":""test"",""enable"":1,""delay"":1800,""act"":1,""remain"":1800}],""err_code"":0}");
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Timer, "get_rules", null)).Returns(json);
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Timer, "get_rules", null, null)).Returns(json);
 
         Timer actual = (await Outlet.Timer.Get())!.Value;
         actual.Name.Should().Be("test");
@@ -24,7 +24,7 @@ public class KasaOutletTimerTest: AbstractKasaOutletTest {
     [Fact]
     public async Task GetElapsed() {
         JObject json = JObject.Parse(@"{""rule_list"":[{""id"":""BD8AED3F853C175935F0A5BC24C454F4"",""name"":""test"",""enable"":0,""delay"":0,""act"":1,""remain"":0}],""err_code"":0}");
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Timer, "get_rules", null)).Returns(json);
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Timer, "get_rules", null, null)).Returns(json);
 
         Timer? actual = await Outlet.Timer.Get();
         actual.Should().BeNull();
@@ -33,7 +33,7 @@ public class KasaOutletTimerTest: AbstractKasaOutletTest {
     [Fact]
     public async Task GetNone() {
         JObject json = JObject.Parse(@"{""rule_list"":[],""err_code"":0}");
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Timer, "get_rules", null)).Returns(json);
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Timer, "get_rules", null, null)).Returns(json);
 
         Timer? actual = await Outlet.Timer.Get();
         actual.Should().BeNull();
@@ -42,14 +42,14 @@ public class KasaOutletTimerTest: AbstractKasaOutletTest {
     [Fact]
     public async Task Clear() {
         JObject json = JObject.Parse(@"{""err_code"":0}");
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Timer, "delete_all_rules", null)).Returns(json);
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Timer, "delete_all_rules", null, null)).Returns(json);
 
         await Outlet.Timer.Clear();
     }
 
     [Fact]
     public async Task Set() {
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Timer, "get_rules", null))
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Timer, "get_rules", null, null))
             .Returns(JObject.Parse(@"{""rule_list"":[{""id"":""BD8AED3F853C175935F0A5BC24C454F4"",""name"":""test"",""enable"":1,""delay"":1800,""act"":1,""remain"":1800}],""err_code"":0}"));
 
         Timer actual = await Outlet.Timer.Start(TimeSpan.FromMinutes(30), true);
@@ -60,9 +60,9 @@ public class KasaOutletTimerTest: AbstractKasaOutletTest {
         actual.RemainingDuration.Should().Be(TimeSpan.FromMinutes(30));
         actual.WillSetOutletOn.Should().BeTrue();
 
-        A.CallTo(() => Client.Send<JObject>(CommandFamily.Timer, "delete_all_rules", null)).MustHaveHappened()
-            .Then(A.CallTo(() => Client.Send<JObject>(CommandFamily.Timer, "add_rule", new Timer(TimeSpan.FromMinutes(30), true))).MustHaveHappened())
-            .Then(A.CallTo(() => Client.Send<JObject>(CommandFamily.Timer, "get_rules", null)).MustHaveHappened());
+        A.CallTo(() => Client.Send<JObject>(CommandFamily.Timer, "delete_all_rules", null, null)).MustHaveHappened()
+            .Then(A.CallTo(() => Client.Send<JObject>(CommandFamily.Timer, "add_rule", new Timer(TimeSpan.FromMinutes(30), true), null)).MustHaveHappened())
+            .Then(A.CallTo(() => Client.Send<JObject>(CommandFamily.Timer, "get_rules", null, null)).MustHaveHappened());
     }
 
 }


### PR DESCRIPTION
Not yet working!  This is for reference only.  I am attempting to add support fo  optional string[] parameter to Send() for children. Send() optionally adds 'context' property.  Send() appears to correctly send correct JSON but device is still only enabling one plug.

See  https://community.home-assistant.io/t/tp-link-kasa-kp400-2-outlet-support/113135/9 for reference.    
{"system":{"set_relay_state":{"state":0}},"context":{"child_ids":["000000000000000000000000"]}}